### PR TITLE
Described what the base64 representation should look like for iOS.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Basic SMTP client cordova plugin for editing and sending email messages.
 
-## Using
+## Installation
 
 Install iOS and/or Android platform
 
@@ -13,7 +13,9 @@ Install the plugin using any plugman compatible cli
 
     $ cordova plugin add https://github.com/CWBudde/cordova-plugin-smtp-client.git
 
-On your javascript call use a code similar to this.
+## Usage
+
+On Javascript, use code that is similar to the following.
 
 	var mailSettings = {
 	    emailFrom: "emailFrom@domain.com",
@@ -21,7 +23,7 @@ On your javascript call use a code similar to this.
 	    smtp: "smtp-mail.domain.com",
 	    smtpUserName: "authuser@domain.com",
 	    smtpPassword: "password",
-	    attachments: ["attchament1","attchament2"],
+	    attachments: ["attachment1", "attachment2"],
 	    subject: "email subject",
 	    textBody: "write something within the body of the email"
 	};
@@ -36,18 +38,26 @@ On your javascript call use a code similar to this.
 				
 	smtpClient.sendMail(mailSettings, success, failure);
 
-The attachments is an array of strings where when using IOS the files needs to be in [DATA_URI format](doc/attachments.md) and when Android should be the path of the file.
+### Attachments
+
+The attachments is an array of strings.
+
+On the iOS platform, it must use a [DATA_URI format](doc/attachments.md).
+
+On the Android platform, it must be the path to the file.
+
+### Return type
 	
 The return object "message" has the following structure
 
 	{
-		success: bool,
-		errorCode: int,
+		success: boolean,
+		errorCode: number,
 		errorMessage: string	    
 	}
 
 ## Copyright
 
-The library was originally written by albernazf (https://github.com/albernazf/cordova-smtp-client) and later modified by Nelson Medina Humberto (https://github.com/nelsonhumberto/cordova-smtp-client/).
+The library was originally written by albernazf ([cordova-smtp-client](https://github.com/albernazf/cordova-smtp-client)) and later modified by Nelson Medina Humberto ([cordova-smtp-client](https://github.com/nelsonhumberto/cordova-smtp-client/)).
 
-On iOS it makes use of the skpsmtpmessage library, which was originally written by Ian Baird. A recent fork can be found here: https://github.com/jetseven/skpsmtpmessage  
+On iOS it makes use of the skpsmtpmessage library, which was originally written by Ian Baird. A recent fork can be found on ([skpsmtpmessage](https://github.com/jetseven/skpsmtpmessage)).

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ On your javascript call use a code similar to this.
 				
 	smtpClient.sendMail(mailSettings, success, failure);
 
-The attachments is an array of strings where when using IOS the files needs to be in DATA_URI format and when Android should be the path of the file.
+The attachments is an array of strings where when using IOS the files needs to be in [DATA_URI format](doc/attachments.md) and when Android should be the path of the file.
 	
 The return object "message" has the following structure
 

--- a/doc/attachments.md
+++ b/doc/attachments.md
@@ -2,7 +2,7 @@
 
 ### What should the format of the Base64 string be?
 
-Look at the following code below:
+Look at the following code below for file `APPEmailComposerImpl.m`:
 
 ```ObjectiveC
 /**

--- a/doc/attachments.md
+++ b/doc/attachments.md
@@ -1,0 +1,48 @@
+## On iOS devices
+
+### What should the format of the Base64 string be?
+
+Look at the following code below:
+
+```ObjectiveC
+/**
+ * Returns the data for a given (relative) attachment path.
+ *
+ * @param path An absolute/relative path or the base64 data
+ *
+ * @return The data for the attachment.
+ */
+- (NSData*) getDataForAttachmentPath:(NSString*)path
+{
+    if ([path hasPrefix:@"file:///"])
+    {
+        return [self dataForAbsolutePath:path];
+    }
+    else if ([path hasPrefix:@"res:"])
+    {
+        return [self dataForResource:path];
+    }
+    else if ([path hasPrefix:@"file://"])
+    {
+        return [self dataForAsset:path];
+    }
+    else if ([path hasPrefix:@"app://"])
+    {
+        return [self dataForAppInternalPath:path];
+    }
+    else if ([path hasPrefix:@"base64:"])
+    {
+        return [self dataFromBase64:path];
+    }
+
+    NSFileManager* fm = [NSFileManager defaultManager];
+
+    if (![fm fileExistsAtPath:path]){
+        NSLog(@"File not found: %@", path);
+    }
+
+    return [fm contentsAtPath:path];
+}
+```
+
+The following code recommends that the base 64 representation of the file to be attached must begin with the prefix `base64:data` where data is your data represented in base64.

--- a/doc/attachments.md
+++ b/doc/attachments.md
@@ -1,7 +1,6 @@
-# What should the format of the Base64 string be?
+# What does the Data URI format using Base64 string look like?
 
-## on iOS devices
-
+## On iOS devices
 
 Your full base64 string must look like the following:
 

--- a/doc/attachments.md
+++ b/doc/attachments.md
@@ -1,6 +1,6 @@
-## On iOS devices
+# What should the format of the Base64 string be?
 
-### What should the format of the Base64 string be?
+## on iOS devices
 
 Look at the following code below for file `APPEmailComposerImpl.m`:
 
@@ -45,4 +45,32 @@ Look at the following code below for file `APPEmailComposerImpl.m`:
 }
 ```
 
-The following code recommends that the base 64 representation of the file to be attached must begin with the prefix `base64:data` where data is your data represented in base64.
+The following code points out that for your string to be recognized as a base 64 data representation of the file to be attached, it must begin with the prefix `base64:`.
+
+## Filename
+
+After the base64 prefix, you must specify the file name. From reading the code that parses the base 64 data (dataFromBase64):
+
+```
+- (NSString*) getBasenameFromAttachmentPath:(NSString*)path
+{
+    if ([path hasPrefix:@"base64:"])
+    {
+        NSString* pathWithoutPrefix;
+
+        pathWithoutPrefix = [path stringByReplacingOccurrencesOfString:@"base64:"
+                                                            withString:@""];
+
+        return [pathWithoutPrefix substringToIndex:
+                [pathWithoutPrefix rangeOfString:@"//"].location];
+    }
+
+    return path;
+}
+```
+
+Your full base64 string must look like the following:
+
+```
+base64:filename.ext//yourbase64datahere
+```

--- a/doc/attachments.md
+++ b/doc/attachments.md
@@ -2,6 +2,15 @@
 
 ## on iOS devices
 
+
+Your full base64 string must look like the following:
+
+```
+base64:filename.ext//yourbase64datahere
+```
+
+## Why exactly?
+
 Look at the following code below for file `APPEmailComposerImpl.m`:
 
 ```ObjectiveC
@@ -69,8 +78,3 @@ After the base64 prefix, you must specify the file name. From reading the code t
 }
 ```
 
-Your full base64 string must look like the following:
-
-```
-base64:filename.ext//yourbase64datahere
-```

--- a/doc/attachments.md
+++ b/doc/attachments.md
@@ -57,7 +57,7 @@ The following code points out that for your string to be recognized as a base 64
 
 ## Filename
 
-After the base64 prefix, you must specify the file name. From reading the code that parses the base 64 data (dataFromBase64):
+After the base64 prefix, you must specify the file name. 
 
 ```
 - (NSString*) getBasenameFromAttachmentPath:(NSString*)path
@@ -77,3 +77,4 @@ After the base64 prefix, you must specify the file name. From reading the code t
 }
 ```
 
+From reading the above code, we recognize that it attempts to find the filename between the `base64:` part and the `//` part. This means that the filename must follow right after the base64 prefix, and it must be delimited using `//`.


### PR DESCRIPTION
I tried following the standard [Data URI scheme](https://en.wikipedia.org/wiki/Data_URI_scheme) but it didn't work, saying the error was `File not found`. Debugging it showed me what format it expected for the attachments represented in base64.

I think that this should be included, so as to guide users when attempting to attach files or images.

Let me know if there's anything we can do to improve this. Thanks.